### PR TITLE
add scheme to input hostname, and rename it baseUri

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -41,7 +41,7 @@ functions:
           description: Hourly back up of RabbitMQ topology to CloudWatch
           schedule: rate(1 hour)
           input:
-            hostname: rabbit.us-west-2.${opt:stage}.dwolla.net
+            baseUri: https://rabbit.us-west-2.${opt:stage}.dwolla.net
             username: guest
             password: ${self:custom.Credentials.${opt:stage}}
 

--- a/src/main/scala/com/dwolla/rabbitmq/topology/LambdaHandler.scala
+++ b/src/main/scala/com/dwolla/rabbitmq/topology/LambdaHandler.scala
@@ -13,6 +13,6 @@ class LambdaHandler(printer: Printer) extends IOLambda[RabbitMQConfig, RabbitMqT
                             (input: RabbitMQConfig): IO[Option[RabbitMqTopology]] =
     for {
       password <- KmsAlg.resource[IO].use(_.decrypt(input.password)).map(tagPassword)
-      topology <- RabbitMqTopologyAlg.resource[IO](blocker, input.hostname, input.username, password).use(_.retrieveTopology)
+      topology <- RabbitMqTopologyAlg.resource[IO](blocker, input.baseUri, input.username, password).use(_.retrieveTopology)
     } yield Option(topology)
 }

--- a/src/main/scala/com/dwolla/rabbitmq/topology/model/package.scala
+++ b/src/main/scala/com/dwolla/rabbitmq/topology/model/package.scala
@@ -21,7 +21,7 @@ package object model {
 }
 
 package model  {
-  case class RabbitMQConfig(hostname: Uri, username: Username, password: String)
+  case class RabbitMQConfig(baseUri: Uri, username: Username, password: String)
   object RabbitMQConfig {
     implicit def rabbitMQConfigEncoder[F[_]]: Encoder[RabbitMQConfig] = deriveEncoder
     implicit def rabbitMQConfigDecoder[F[_]]: Decoder[RabbitMQConfig] = deriveDecoder

--- a/src/test/scala/com/dwolla/rabbitmq/topology/EventDeserializationSpec.scala
+++ b/src/test/scala/com/dwolla/rabbitmq/topology/EventDeserializationSpec.scala
@@ -1,0 +1,24 @@
+package com.dwolla.rabbitmq.topology
+
+import com.dwolla.rabbitmq.topology.model.{RabbitMQConfig, Username}
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import io.circe.literal._
+import org.http4s.syntax.all._
+
+class EventDeserializationSpec extends FlatSpec with Matchers with EitherValues {
+
+  behavior of "event deserialization"
+
+  it should "deserialize an example event" in {
+    val input =
+      json"""{
+               "baseUri": "https://rabbit.us-west-2.local.dwolla.net",
+               "username": "guest",
+               "password": "password"
+             }"""
+
+    val expected = RabbitMQConfig(uri"https://rabbit.us-west-2.local.dwolla.net", "guest".asInstanceOf[Username], "password")
+    input.as[RabbitMQConfig].contains(expected) should be(true)
+  }
+
+}


### PR DESCRIPTION
I think currently the Lambda function is trying to talk to the RabbitMQ instances using HTTP instead of HTTPS, so this is more specific about how to connect.