### PR TITLE
avoid serverless custom resource in stack …

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -37,9 +37,9 @@ functions:
           - ','
           - !ImportValue ${self:custom.VpcImportPrefix.${opt:stage}}VpcInternalSubnets
     events:
-      - eventBridge:
+      - schedule:
           description: Hourly back up of RabbitMQ topology to CloudWatch
-          schedule: rate(1 hour)
+          rate: rate(1 hour)
           input:
             baseUri: https://rabbit.us-west-2.${opt:stage}.dwolla.net
             username: guest


### PR DESCRIPTION
… by using cloudwatch event syntax instead of eventbridge

When you call for an `eventBridge` event, serverless uses a CloudFormation custom resource to create the events. But they're (afaict) exactly the same as scheduled CloudWatch Events, which it can create directly using native CloudFormation if you ask for a `schedule` event instead.