### PR TITLE
work around "Connection: keep-alive" timeout bug by specifying "Connection: close"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val buildSettings = Seq(
   mappings in (Compile, packageDoc) := Seq(),
   publishArtifact in (Compile, packageDoc) := false,
   topLevelDirectory := None,
+  packageName in Universal := name.value,
   Compile / scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
@@ -34,9 +35,9 @@ lazy val `rabbitmq-topology-backup` = (project in file("."))
   .settings(buildSettings: _*)
   .settings(
     libraryDependencies ++= {
-      val http4sVersion = "0.21.0"
+      val http4sVersion = "0.21.1"
       val circeVersion = "0.13.0"
-      val fs2AwsVersion = "2.0.0-M8"
+      val fs2AwsVersion = "2.0.0-M9"
       val amazonXRayVersion = "2.4.0"
       Seq(
         "com.amazonaws" % "aws-xray-recorder-sdk-core" % amazonXRayVersion,
@@ -52,6 +53,7 @@ lazy val `rabbitmq-topology-backup` = (project in file("."))
         "org.http4s" %% "http4s-server" % http4sVersion % Test,
         "io.circe" %% "circe-literal" % circeVersion % Test,
         "io.circe" %% "circe-parser" % circeVersion % Test,
+        "io.chrisdavenport" %% "log4cats-slf4j" % "1.0.1" % Test,
       )
     },
   )

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,7 +24,7 @@ provider:
     Visibility: internal
 
 package:
-  artifact: target/universal/rabbitmq-topology-backup-0.0.1-SNAPSHOT.zip
+  artifact: target/universal/rabbitmq-topology-backup.zip
 
 functions:
   backup:
@@ -41,7 +41,7 @@ functions:
           description: Hourly back up of RabbitMQ topology to CloudWatch
           rate: rate(1 hour)
           input:
-            baseUri: https://rabbit.us-west-2.${opt:stage}.dwolla.net
+            baseUri: "http://rabbit.us-west-2.${opt:stage}.dwolla.net:15672"
             username: guest
             password: ${self:custom.Credentials.${opt:stage}}
 

--- a/src/test/scala/com/dwolla/lambda/TestRunner.scala
+++ b/src/test/scala/com/dwolla/lambda/TestRunner.scala
@@ -10,8 +10,9 @@ object TestRunner extends App {
   val logger = LoggerFactory.getLogger("TestRunner")
 
   val input: InputStream = new ByteArrayInputStream(
+//             "baseUri": "http://localhost:15672",
     json"""{
-             "hostname": "https://rabbit.us-west-2.devint.dwolla.net",
+             "baseUri": "http://rabbit.us-west-2.devint.dwolla.net:15672",
              "username": "guest",
              "password": "AQICAHh38+DAqADvcRLU4+t2AYhr82YbZuuFQdjdX95NTppHhwHd8XtgUIF6t8gP+mKlCrizAAAAYzBhBgkqhkiG9w0BBwagVDBSAgEAME0GCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMuvCOEA4D/QGIaihbAgEQgCATYPnSoUh0UI+QsqlR00kP7cGLdyh6fUrfBv7Gzt8ToA=="
            }""".noSpaces.getBytes)
@@ -20,5 +21,5 @@ object TestRunner extends App {
 
   new LambdaHandler().handleRequest(input, output, null)
 
-  logger.info("{}", output)
+  logger.info("{}", output.size())
 }


### PR DESCRIPTION
There is a bug in the ember HTTP library that's causing our requests to be held open until the server closes the connection. The default ELB idle timeout is 60 seconds. Adding `Connection: close` to the HTTP request will tell the server to close the connection as soon as it's done sending the response.

I think there may be a race condition in the handling of the TLS stream, so I'm temporarily switching this to use HTTP over port 15672 instead, until I figure out what's going wrong there.